### PR TITLE
Insert focus before last "do", not first

### DIFF
--- a/src/rspec-focus.ts
+++ b/src/rspec-focus.ts
@@ -52,7 +52,7 @@ function add() {
                 if (matches[0].includes(', focus: true')) {
                     continue;
                 } else {
-                    let position = new Position(i, text.indexOf('do') - 1);
+                    let position = new Position(i, text.lastIndexOf('do') - 1);
                     edit.replace(position, ', focus: true');
                     break;
                 }


### PR DESCRIPTION
Hey @asux, thanks for making this extension. I've found it really useful over the last few months. This is a small bug fix I've made that I'd love to get merged. I'm not sure how the update process works for VS Code Extensions, but I'm happy to help in any way I can.

# What changed?

Previously, using this extension would insert `, focus: true` before the first occurrence of `do` on a line. That meant that if a block description contained `do`, this extension would not work correctly. For example, the line:

```ruby
it "does something" do
```

would become:

```ruby
it, focus: true "does something" do
```

Now it correctly becomes

```ruby
it "does something", focus: true do
```